### PR TITLE
fix: rerender likely causing cursor jumping

### DIFF
--- a/src/screens/Editor.tsx
+++ b/src/screens/Editor.tsx
@@ -20,6 +20,7 @@ export default function Editor({ editorRef, fileData, handleFileDataChange }) {
           minimap: { enabled: false },
           wordWrap: "on",
           suggest: { showWords: false },
+          lineNumbers: "relative",
         }}
         defaultLanguage="markdown"
         onMount={handleEditorDidMount}

--- a/src/screens/Editor.tsx
+++ b/src/screens/Editor.tsx
@@ -28,7 +28,7 @@ export default function Editor({ editorRef, fileData, handleFileDataChange }) {
         value={fileData}
         onChange={handleFileDataChange}
       />
-      <div className="fixed bottom-0 flex w-full items-center border-t-2 border-white">
+      <div className="fixed bottom-0 flex w-full items-center border-t-2 border-white bg-gray-900">
         <div
           ref={statusBarRef}
           className="h-8 w-50 border-r-2 border-r-white px-4 py-1 text-white"

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -174,8 +174,6 @@ function Home() {
 
     filesData.current[selectedFileIdx.current].content = e;
     filesData.current[selectedFileIdx.current].updated_at = new Date();
-
-    forceRerender((n) => n + 1);
   };
 
   const debounceDataFn = useCallback(_debounce(handleFileDataChange, 500), [


### PR DESCRIPTION
Changes:
- Fixed rerender in update API call likely causing the cursor to jump to unintended places
- Added relative line numbers
- Added background to the bottom status bar element